### PR TITLE
Use Fastmcp and setup devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+    "name": "Python 3",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+          "version": "lts"
+        },
+        "ghcr.io/jsburckhardt/devcontainer-features/uv:1":{}
+      },
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "pip install mcp[cli]"
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+
+    // Set environment variables
+}

--- a/jattavagen_departures/fetch_data.py
+++ b/jattavagen_departures/fetch_data.py
@@ -23,7 +23,7 @@ def fetch_timetable():
     logger.info(f"Fetching timetable at {current_time_iso}")
     
     # Build the XML request body dynamically
-    xml_request = f\"\"\"<?xml version="1.0" encoding="UTF-8"?>
+    xml_request = f"""<?xml version="1.0" encoding="UTF-8"?>
 <Siri xmlns="http://www.siri.org.uk/siri" version="2.1"
       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -44,7 +44,7 @@ def fetch_timetable():
     </EstimatedTimetableRequest>
   </ServiceRequest>
 </Siri>
-\"\"\"
+"""
 
     headers = {
         "Content-Type": "application/xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,4 @@
-blinker==1.9.0
-certifi==2025.1.31
-charset-normalizer==3.4.1
-click==8.1.8
-Flask==3.1.0
-idna==3.10
-itsdangerous==2.2.0
-Jinja2==3.1.5
-MarkupSafe==3.0.2
-requests==2.32.3
-urllib3==2.3.0
-Werkzeug==3.1.3
+mcp
+requests
+python-dotenv
+pydantic

--- a/server.py
+++ b/server.py
@@ -1,52 +1,54 @@
-# server.py
-import logging
-from flask import Flask, jsonify, request
+import os
+from typing import Dict, Any
+
+from dotenv import load_dotenv
+from mcp.server.fastmcp import FastMCP, Context
+from pydantic import Field
+
 from jattavagen_departures.service import get_upcoming_departures, format_departures
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+# Load environment variables
+load_dotenv()
+
+# Get Application Insights credentials
+API_ENDPOINT = os.getenv("API_ENDPOINT")
+SUBSCRIPTION_KEY = os.getenv("SUBSCRIPTION_KEY")
+REQUESTOR_REF=os.getenv("REQUESTOR_REF")
+
+# Validate environment variables
+if not API_ENDPOINT or not SUBSCRIPTION_KEY or not REQUESTOR_REF:
+    raise ValueError("API_ENDPOINT, SUBSCRIPTION_KEY and REQUESTOR_REF must be set in .env file")
+
+# Create an MCP server
+mcp = FastMCP(
+    name="Togtider", 
+    log_level="DEBUG", 
+    debug=True, 
+    port=8080
 )
-logger = logging.getLogger('togtider-server')
 
-app = Flask(__name__)
-
-@app.route('/departures', methods=['GET'])
-def departures():
+@mcp.tool()
+def togtider(
+#    station: str = Field(description="The train station to get departures for", default="Jåttåvågen"), 
+    ctx: Context = Field(description="MCP context")
+) -> Dict[str, Any]:
     """
     Endpoint to get departures from Jåttåvågen station.
     Returns JSON with northbound and southbound departures.
     """
-    try:
-        logger.info(f"Request received from {request.remote_addr}")
-        deps = get_upcoming_departures()
-        formatted = format_departures(deps)
+    deps = get_upcoming_departures()
+    formatted = format_departures(deps)
         
-        # Add metadata to the response
-        response = {
-            "data": formatted,
-            "station": "Jåttåvågen",
-            "timestamp": formatted.get("timestamp", None)
-        }
-        
-        logger.info(f"Returning {sum(len(deps) for deps in formatted.values() if isinstance(deps, list))} departures")
-        return jsonify(response), 200
-    
-    except Exception as e:
-        logger.error(f"Error processing departure request: {str(e)}", exc_info=True)
-        return jsonify({
-            "error": "Failed to retrieve departure information",
-            "message": str(e)
-        }), 500
+    # Add metadata to the response
+    return  {
+        "data": formatted,
+        "station": "Jåttåvågen",
+        "timestamp": formatted.get("timestamp", None)
+    }
 
-@app.route('/health', methods=['GET'])
-def health_check():
-    """
-    Simple health check endpoint
-    """
-    return jsonify({"status": "ok"}), 200
+if __name__ == "__main__":
+    mcp.run(transport="sse")
 
-if __name__ == '__main__':
-    logger.info("Starting Togtider server on port 5001")
-    app.run(host='127.0.0.1', port=5001, debug=False)
+# Alternatively run with: mcp run server.py --transport sse
+# Or with MCP Inspector with: npx @modelcontextprotocol/inspector

--- a/server.py
+++ b/server.py
@@ -9,16 +9,16 @@ from jattavagen_departures.service import get_upcoming_departures, format_depart
 
 
 # Load environment variables
-load_dotenv()
+#load_dotenv()
 
 # Get Application Insights credentials
-API_ENDPOINT = os.getenv("API_ENDPOINT")
-SUBSCRIPTION_KEY = os.getenv("SUBSCRIPTION_KEY")
-REQUESTOR_REF=os.getenv("REQUESTOR_REF")
+#API_ENDPOINT = os.getenv("API_ENDPOINT")
+#SUBSCRIPTION_KEY = os.getenv("SUBSCRIPTION_KEY")
+#REQUESTOR_REF=os.getenv("REQUESTOR_REF")
 
 # Validate environment variables
-if not API_ENDPOINT or not SUBSCRIPTION_KEY or not REQUESTOR_REF:
-    raise ValueError("API_ENDPOINT, SUBSCRIPTION_KEY and REQUESTOR_REF must be set in .env file")
+#if not API_ENDPOINT or not SUBSCRIPTION_KEY or not REQUESTOR_REF:
+#    raise ValueError("API_ENDPOINT, SUBSCRIPTION_KEY and REQUESTOR_REF must be set in .env file")
 
 # Create an MCP server
 mcp = FastMCP(


### PR DESCRIPTION
server.py

Using the Fastmcp class and the @mcp.tool() annotation.

If there are parameters to the MCP tool, you can use pydantic  to describe it (now commented out
`#    station: str = Field(description="The train station to get departures for", default="Jåttåvågen"), `

Run directly through the lines
```
if __name__ == "__main__":
    mcp.run(transport="sse")
```

devcontainer,json
Added a devcontainer with necessary dependencies to simplify development (requires docker installed locally and the devcontainer vs code extension)


To test
Run `python server.py`  or `mcp run server.py --transport sse` to start server with sse transport on port 8080.
(run `mcp run server.py --transport stdio` to start server with standard io)

Then run `npx @modelcontextprotocol/inspector` and connect with sse against port 8080
